### PR TITLE
Implement working search endpoint and stub scrapers

### DIFF
--- a/backend/ai/interpreter.js
+++ b/backend/ai/interpreter.js
@@ -1,1 +1,11 @@
-// interpreter.js content
+/**
+ * Extrae un precio máximo simple desde la consulta.
+ * Retorna un objeto con la consulta original y el precio detectado.
+ */
+function interpret(consulta) {
+  const priceMatch = consulta.match(/(\d+)/);
+  const precioMax = priceMatch ? parseInt(priceMatch[1] || priceMatch[0], 10) : null;
+  return { consulta, precioMax };
+}
+
+module.exports = { interpret };

--- a/backend/routes/buscar.js
+++ b/backend/routes/buscar.js
@@ -1,1 +1,17 @@
-// buscar.js route
+const express = require('express');
+const ejecutarScrapers = require('../scrapers');
+
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const { consulta = '' } = req.body || {};
+    const resultados = await ejecutarScrapers(consulta);
+    res.json({ filtro: { consulta }, resultados });
+  } catch (err) {
+    console.error('Error en /api/buscar:', err);
+    res.status(500).json({ error: 'Error al procesar la búsqueda' });
+  }
+});
+
+module.exports = router;

--- a/backend/scrapers/almundo.js
+++ b/backend/scrapers/almundo.js
@@ -1,1 +1,13 @@
-// almundo scraper
+async function almundo(consulta) {
+  // Aquí iría el scraping real a Almundo. Para efectos de ejemplo
+  // devolvemos datos estáticos.
+  return [
+    {
+      sitio: 'Almundo',
+      titulo: `Oferta Almundo para ${consulta}`,
+      precio: 150000,
+    },
+  ];
+}
+
+module.exports = almundo;

--- a/backend/scrapers/index.js
+++ b/backend/scrapers/index.js
@@ -1,1 +1,14 @@
-// index for scrapers
+const almundo = require('./almundo');
+const kayak = require('./kayak');
+const turismocity = require('./turismocity');
+
+async function ejecutarTodos(consulta) {
+  const resultados = await Promise.all([
+    almundo(consulta),
+    kayak(consulta),
+    turismocity(consulta),
+  ]);
+  return resultados.flat();
+}
+
+module.exports = ejecutarTodos;

--- a/backend/scrapers/kayak.js
+++ b/backend/scrapers/kayak.js
@@ -1,1 +1,11 @@
-// kayak scraper
+async function kayak(consulta) {
+  return [
+    {
+      sitio: 'Kayak',
+      titulo: `Resultado Kayak para ${consulta}`,
+      precio: 160000,
+    },
+  ];
+}
+
+module.exports = kayak;

--- a/backend/scrapers/turismocity.js
+++ b/backend/scrapers/turismocity.js
@@ -1,1 +1,11 @@
-// turismocity scraper
+async function turismocity(consulta) {
+  return [
+    {
+      sitio: 'Turismocity',
+      titulo: `Propuesta Turismocity para ${consulta}`,
+      precio: 155000,
+    },
+  ];
+}
+
+module.exports = turismocity;

--- a/frontend/src/components/Buscador.jsx
+++ b/frontend/src/components/Buscador.jsx
@@ -7,7 +7,7 @@ export default function Buscador() {
 
   const handleBuscar = async (e) => {
     e.preventDefault();
-    const res = await fetch('https://vuelosbaratos.onrender.com/api/buscar', {
+    const res = await fetch('/api/buscar', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ consulta }),


### PR DESCRIPTION
## Summary
- implement `/api/buscar` route
- add simple stub scrapers and aggregator
- add basic query interpreter
- adjust frontend to call relative API path

## Testing
- `npm install --silent` in `backend`
- `node backend/index.js &` then `curl -X POST -H "Content-Type: application/json" -d '{"consulta":"viaje"}' http://localhost:4000/api/buscar`
- `npm install --silent` in `frontend`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_687f07eb2f4c8324baace8da12427d6b