### PR TITLE
Add glob pattern for nested env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 npm-debug.log*
 # Env files
 .env
+**/.env
 # lock files
 package-lock.json
 yarn.lock


### PR DESCRIPTION
## Summary
- ignore nested `.env` files with new `**/.env` pattern

## Testing
- `git status --ignored -s | grep testignore`

------
https://chatgpt.com/codex/tasks/task_e_687fe2f401188324b1a604b6d4e363fb