### PR TITLE
Fix search filtering and build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# VuelosBaratos
+
+Aplicación simple para buscar ofertas de vuelos y paquetes. Incluye un backend Node.js con scrapers de ejemplo y un frontend React con Tailwind.
+
+## Requisitos
+- Node.js 16+
+
+## Instalación
+```bash
+# Backend
+cd backend
+npm install
+
+# Frontend
+cd ../frontend
+npm install
+```
+
+## Desarrollo
+Para ejecutar en modo desarrollo es necesario correr el backend y el frontend por separado.
+
+```bash
+# Iniciar backend
+cd backend
+npm start
+
+# En otra terminal iniciar frontend
+cd frontend
+npm run dev
+```
+
+El frontend está configurado para proxy `/api` hacia `http://localhost:4000`.
+
+## Compilar
+```bash
+cd frontend
+npm run build
+```

--- a/backend/routes/buscar.js
+++ b/backend/routes/buscar.js
@@ -1,13 +1,22 @@
 const express = require('express');
 const ejecutarScrapers = require('../scrapers');
+const { interpret } = require('../ai/interpreter');
 
 const router = express.Router();
 
 router.post('/', async (req, res) => {
   try {
     const { consulta = '' } = req.body || {};
-    const resultados = await ejecutarScrapers(consulta);
-    res.json({ filtro: { consulta }, resultados });
+    const { precioMax } = interpret(consulta);
+
+    let resultados = await ejecutarScrapers(consulta);
+    if (precioMax) {
+      resultados = resultados.filter(r =>
+        typeof r.precio === 'number' && r.precio <= precioMax
+      );
+    }
+
+    res.json({ filtro: { consulta, precioMax }, resultados });
   } catch (err) {
     console.error('Error en /api/buscar:', err);
     res.status(500).json({ error: 'Error al procesar la búsqueda' });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,9 +11,10 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "vite": "^4.0.0",
-    "tailwindcss": "^3.0.0",
+    "@vitejs/plugin-react": "^4.1.0",
+    "autoprefixer": "^10.0.0",
     "postcss": "^8.0.0",
-    "autoprefixer": "^10.0.0"
+    "tailwindcss": "^3.0.0",
+    "vite": "^4.0.0"
   }
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:4000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- parse query on the backend and filter results by price
- add Vite config with proxy and React plugin
- configure PostCSS for Tailwind
- document how to run the project

## Testing
- `npm start` in `backend`
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"consulta":"viaje 155000"}' http://localhost:4000/api/buscar | jq`
- `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687ffb9f15448324a4526058090765e2