### PR TITLE
Fix deployment configuration for Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ npm run dev
 
 El frontend está configurado para proxy `/api` hacia `http://localhost:4000`.
 
+## Ejecución en producción
+
+Compila el frontend y luego inicia el servidor con Node en modo producción:
+
+```bash
+npm run start:build
+```
+
 ## Despliegue en Vercel
 Vercel usará el archivo `vercel.json` para construir el frontend con Vite y las
 funciones de la carpeta `api`. Ejecuta `npm install` y luego `npm run build` para

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# VuelosBaratos
+
+Aplicación simple para buscar ofertas de vuelos y paquetes. Incluye un backend Node.js con scrapers de ejemplo y un frontend React con Tailwind.
+
+## Requisitos
+- Node.js 16+
+
+## Instalación
+```bash
+# Instala todas las dependencias (frontend y backend)
+npm install
+```
+
+## Desarrollo
+Para ejecutar en modo desarrollo es necesario correr el backend y el frontend por separado.
+
+```bash
+# Iniciar backend
+cd backend
+npm start
+
+# En otra terminal iniciar frontend
+cd frontend
+npm run dev
+```
+
+El frontend está configurado para proxy `/api` hacia `http://localhost:4000`.
+
+## Despliegue en Vercel
+Vercel usará el archivo `vercel.json` para construir el frontend con Vite y las
+funciones de la carpeta `api`. Ejecuta `npm install` y luego `npm run build` para
+generar `frontend/dist`. El backend será accesible bajo `/api`.
+
+## Compilar
+```bash
+cd frontend
+npm run build
+```

--- a/README.md
+++ b/README.md
@@ -28,10 +28,17 @@ El frontend está configurado para proxy `/api` hacia `http://localhost:4000`.
 
 ## Ejecución en producción
 
-Compila el frontend y luego inicia el servidor con Node en modo producción:
+Ejecuta `npm start`. Este comando compila el frontend y a continuación arranca
+el backend en modo producción:
 
 ```bash
-npm run start:build
+npm start
+```
+
+Si ya tienes el frontend compilado y solo quieres iniciar el servidor puedes usar:
+
+```bash
+npm run start:prod
 ```
 
 ## Despliegue en Vercel

--- a/api/buscar.js
+++ b/api/buscar.js
@@ -1,0 +1,28 @@
+const ejecutarScrapers = require('../backend/scrapers');
+const { interpret } = require('../backend/ai/interpreter');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  let raw = '';
+  for await (const chunk of req) raw += chunk;
+  const body = raw ? JSON.parse(raw) : {};
+  const { consulta = '' } = body;
+
+  try {
+    const { precioMax } = interpret(consulta);
+    let resultados = await ejecutarScrapers(consulta);
+    if (precioMax) {
+      resultados = resultados.filter(r =>
+        typeof r.precio === 'number' && r.precio <= precioMax
+      );
+    }
+    res.status(200).json({ filtro: { consulta, precioMax }, resultados });
+  } catch (err) {
+    console.error('Error en /api/buscar:', err);
+    res.status(500).json({ error: 'Error al procesar la búsqueda' });
+  }
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,11 +1,21 @@
 const express = require('express');
 const cors = require('cors');
+const path = require('path');
 const app = express();
 
 app.use(cors());
 app.use(express.json());
 
 app.use('/api/buscar', require('./routes/buscar'));
+
+// En producción sirve el frontend estático
+if (process.env.NODE_ENV === 'production') {
+  const dist = path.join(__dirname, '../frontend/dist');
+  app.use(express.static(dist));
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(dist, 'index.html'));
+  });
+}
 
 app.listen(process.env.PORT || 4000, () => {
   console.log('Servidor corriendo en puerto', process.env.PORT || 4000);

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
+const fs = require('fs');
 const app = express();
 
 app.use(cors());
@@ -11,6 +12,9 @@ app.use('/api/buscar', require('./routes/buscar'));
 // En producción sirve el frontend estático
 if (process.env.NODE_ENV === 'production') {
   const dist = path.join(__dirname, '../frontend/dist');
+  if (!fs.existsSync(path.join(dist, 'index.html'))) {
+    console.warn('No se encontró frontend/dist. Ejecuta `npm run build` antes de iniciar.');
+  }
   app.use(express.static(dist));
   app.get('*', (req, res) => {
     res.sendFile(path.join(dist, 'index.html'));

--- a/backend/routes/buscar.js
+++ b/backend/routes/buscar.js
@@ -1,13 +1,22 @@
 const express = require('express');
 const ejecutarScrapers = require('../scrapers');
+const { interpret } = require('../ai/interpreter');
 
 const router = express.Router();
 
 router.post('/', async (req, res) => {
   try {
     const { consulta = '' } = req.body || {};
-    const resultados = await ejecutarScrapers(consulta);
-    res.json({ filtro: { consulta }, resultados });
+    const { precioMax } = interpret(consulta);
+
+    let resultados = await ejecutarScrapers(consulta);
+    if (precioMax) {
+      resultados = resultados.filter(r =>
+        typeof r.precio === 'number' && r.precio <= precioMax
+      );
+    }
+
+    res.json({ filtro: { consulta, precioMax }, resultados });
   } catch (err) {
     console.error('Error en /api/buscar:', err);
     res.status(500).json({ error: 'Error al procesar la búsqueda' });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,9 +11,10 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "vite": "^4.0.0",
-    "tailwindcss": "^3.0.0",
+    "@vitejs/plugin-react": "^4.1.0",
+    "autoprefixer": "^10.0.0",
     "postcss": "^8.0.0",
-    "autoprefixer": "^10.0.0"
+    "tailwindcss": "^3.0.0",
+    "vite": "^4.0.0"
   }
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:4000'
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "workspaces": ["frontend", "backend"],
   "scripts": {
     "build": "npm --workspace frontend run build",
-    "start": "node backend/index.js"
+    "start": "NODE_ENV=production node backend/index.js",
+    "start:build": "npm run build && npm start"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "vuelosbaratos",
+  "private": true,
+  "workspaces": ["frontend", "backend"],
+  "scripts": {
+    "build": "npm --workspace frontend run build",
+    "start": "node backend/index.js"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": ["frontend", "backend"],
   "scripts": {
     "build": "npm --workspace frontend run build",
-    "start": "NODE_ENV=production node backend/index.js",
-    "start:build": "npm run build && npm start"
+    "start": "npm run build && NODE_ENV=production node backend/index.js",
+    "start:prod": "NODE_ENV=production node backend/index.js"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,7 @@
   ],
   "routes": [
     { "src": "/api/(.*)", "dest": "/api/$1.js" },
-    { "src": "/(.*)", "dest": "/frontend/dist/$1" }
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/frontend/dist/index.html" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "api/*.js", "use": "@vercel/node" },
+    { "src": "frontend/package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/$1.js" },
+    { "src": "/(.*)", "dest": "/frontend/dist/$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- serve built frontend from Express in production
- expose search endpoint as Vercel function
- add root package.json and vercel.json
- document Vercel deployment steps

## Testing
- `npm run build`
- `npm start` then `curl -s -X POST -H 'Content-Type: application/json' -d '{"consulta":"viaje 155000"}' http://localhost:4000/api/buscar | jq`


------
https://chatgpt.com/codex/tasks/task_e_687ffb9f15448324a4526058090765e2