### PR TITLE
Simplify backend server and adjust scripts

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,8 +1,5 @@
 const express = require('express');
 const cors = require('cors');
-const path = require('path');
-const fs = require('fs');
-
 const app = express();
 
 app.use(cors());
@@ -10,20 +7,8 @@ app.use(express.json());
 
 app.use('/api/buscar', require('./routes/buscar'));
 
-// En producción sirve el frontend estático
-if (process.env.NODE_ENV === 'production') {
-  const dist = path.join(__dirname, '../frontend/dist');
-  if (!fs.existsSync(path.join(dist, 'index.html'))) {
-    console.warn('No se encontró frontend/dist. Ejecuta `npm run build` antes de iniciar.');
-  }
-
-  app.use(express.static(dist));
-  app.get('*', (req, res) => {
-    res.sendFile(path.join(dist, 'index.html'));
-  });
-}
-
-app.listen(process.env.PORT || 4000, () => {
-  console.log('Servidor corriendo en puerto', process.env.PORT || 4000);
+const PORT = process.env.PORT || 10000;
+app.listen(PORT, () => {
+  console.log(`Servidor corriendo en puerto ${PORT}`);
 });
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": ["frontend", "backend"],
   "scripts": {
     "build": "npm --workspace frontend run build",
-    "start": "npm run build && NODE_ENV=production node backend/index.js",
+    "start": "NODE_ENV=production node backend/index.js",
     "start:prod": "NODE_ENV=production node backend/index.js"
   }
 }


### PR DESCRIPTION
## Summary
- simplify `backend/index.js` to run only the API server
- remove frontend build step from root start script

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68806e72ed8c8324b51c4f8c4c5dbc90